### PR TITLE
Always point to latest Cucumber & JUnit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,8 +10,6 @@
 
     <properties>
         <java.version>1.7</java.version>
-        <junit.version>4.12</junit.version>
-        <cucumber.version>1.2.2</cucumber.version>
         <maven.compiler.version>3.3</maven.compiler.version>
     </properties>
 
@@ -19,21 +17,21 @@
         <dependency>
             <groupId>info.cukes</groupId>
             <artifactId>cucumber-java</artifactId>
-            <version>${cucumber.version}</version>
+            <version>RELEASE</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>info.cukes</groupId>
             <artifactId>cucumber-junit</artifactId>
-            <version>${cucumber.version}</version>
+            <version>RELEASE</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
+            <version>RELEASE</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
(This is just a drive-by PR made via the web as I was reading this file; mea culpa)

In the skeleton projects I maintain, I hate having to manually bump versions to my libs,  so this would let you prevent that by always running the latest version for new users